### PR TITLE
[Bug Fix] Fix create/update times not rendering on admin user edit page

### DIFF
--- a/app/client/views/admin/user/adminUserCtrl.js
+++ b/app/client/views/admin/user/adminUserCtrl.js
@@ -6,7 +6,9 @@ angular.module('reg')
     '$http',
     'user',
     'UserService',
-    function ($scope, $http, User, UserService) {
+    'Utils',
+    function ($scope, $http, User, UserService, Utils) {
+      $scope.formatTime = Utils.formatTime;
       $scope.selectedUser = User.data;
 
       // Populate the school dropdown


### PR DESCRIPTION
# Description
Previously, the user edit page did not properly render the created on and last updated time stamps. This was because the date formatter was not included in the scope of that page. This diff re adds that.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested

1. Visit /admin/users
2. Select the edit button on a user
3. Check to see the created on and last updated fields are rendered properly

## Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/20614843/103445351-f495ad80-4c40-11eb-8d36-cab6f56e461e.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
